### PR TITLE
Added TCP and UDP Data Validation support

### DIFF
--- a/src/iperf.h
+++ b/src/iperf.h
@@ -88,10 +88,12 @@ struct iperf_interval_results
     int       interval_packet_count;
     int       interval_outoforder_packets;
     int       interval_cnt_error;
+    int       interval_data_error;
     int       packet_count;
     double    jitter;
     int       outoforder_packets;
     int       cnt_error;
+    int       data_error;
 
     int omitted;
 #if (defined(linux) || defined(__FreeBSD__) || defined(__NetBSD__)) && \
@@ -204,6 +206,7 @@ struct iperf_stream
     int       outoforder_packets;
     int       omitted_outoforder_packets;
     int       cnt_error;
+    int       data_error;
     int       omitted_cnt_error;
     uint64_t  target;
 
@@ -307,6 +310,7 @@ struct iperf_test
     int	      json_output;                      /* -J option - JSON output */
     int	      zerocopy;                         /* -Z option - use sendfile */
     int	      zc_api;                           /* --zc_api option - use socket API */
+    int       data_val;                         /* -x option - data validate */
     int	      disable_cookie_check;             /* --disable_cookie option */
     int       debug;				/* -d option - enable debug */
     int	      get_server_output;		/* --get-server-output */

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -3224,17 +3224,14 @@ iperf_print_intermediate(struct iperf_test *test)
                         /* Interval sum, TCP with retransmits. */
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, (int64_t) retransmits, irp->omitted, stream_must_be_sender)); /* XXX irp->omitted or test->omitting? */
-                        else {
+                        else 
                             iperf_printf(test, report_sum_bw_retrans_format, mbuf, start_time, end_time, ubuf, nbuf, retransmits, irp->omitted?report_omitted:""); /* XXX irp->omitted or test->omitting? */
-                        }
                     } else {
                         /* Interval sum, TCP without retransmits. */
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, test->omitting, stream_must_be_sender));
-                        else {
+                        else
                             iperf_printf(test, report_sum_bw_format, mbuf, start_time, end_time, ubuf, nbuf, test->omitting?report_omitted:"");
-
-                        }                            
                     }
                 } else {
                     /* Interval sum, UDP. */
@@ -3253,9 +3250,8 @@ iperf_print_intermediate(struct iperf_test *test)
                         }
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, test->omitting, stream_must_be_sender));
-                        else {
+                        else 
                             iperf_printf(test, report_sum_bw_udp_format, mbuf, start_time, end_time, ubuf, nbuf, avg_jitter * 1000.0, lost_packets, total_packets, lost_percent, test->omitting?report_omitted:"");
-                        }                            
                     }
                 }
             }

--- a/src/iperf_api.c
+++ b/src/iperf_api.c
@@ -923,6 +923,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 #endif /* HAVE_FLOWLABEL */
         {"zerocopy", no_argument, NULL, 'Z'},
         {"zc_api", no_argument, NULL, OPT_ZC_SOCK_API },
+        {"dataval", no_argument, NULL, 'x'},
 #if defined(HAVE_LIBURING)
         {"io_uring", no_argument, NULL, OPT_IO_URING_API },
 #endif
@@ -982,7 +983,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
     char *client_username = NULL, *client_rsa_public_key = NULL, *server_rsa_private_key = NULL;
 #endif /* HAVE_SSL */
 
-    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hX:", longopts, NULL)) != -1) {
+    while ((flag = getopt_long(argc, argv, "p:f:i:D1VJvsc:ub:t:n:k:l:P:Rw:B:M:N46S:L:ZO:F:A:T:C:dI:hxX:", longopts, NULL)) != -1) {
         switch (flag) {
             case 'p':
 		portno = atoi(optarg);
@@ -1399,6 +1400,10 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
 		test->settings->connect_timeout = unit_atoi(optarg);
 		client_flag = 1;
 		break;
+            case 'x':
+		test->data_val = 1;
+                break;
+
 	    case 'h':
 		usage_long(stdout);
 		exit(0);
@@ -1984,6 +1989,9 @@ send_parameters(struct iperf_test *test)
 #endif // HAVE_SSL
 	cJSON_AddStringToObject(j, "client_version", IPERF_VERSION);
 
+	if (test->data_val)
+ 	    cJSON_AddTrueToObject(j, "data_validation");
+
 	if (test->debug) {
 	    char *str = cJSON_Print(j);
 	    printf("send_parameters:\n%s\n", str);
@@ -2080,6 +2088,10 @@ get_parameters(struct iperf_test *test)
 	if ((j_p = cJSON_GetObjectItem(j, "authtoken")) != NULL)
         test->settings->authtoken = strdup(j_p->valuestring);
 #endif //HAVE_SSL
+
+        if ((j_p = cJSON_GetObjectItem(j, "data_validation")) != NULL)
+	    test->data_val = j_p->valueint;
+
 	if (test->mode && test->protocol->id == Ptcp && has_tcpinfo_retransmits())
 	    test->sender_has_retransmits = 1;
 	if (test->settings->rate)
@@ -2170,6 +2182,7 @@ send_results(struct iperf_test *test)
 		    cJSON_AddNumberToObject(j_stream, "retransmits", retransmits);
 		    cJSON_AddNumberToObject(j_stream, "jitter", sp->jitter);
 		    cJSON_AddNumberToObject(j_stream, "errors", sp->cnt_error);
+                    cJSON_AddNumberToObject(j_stream, "data_errors", sp->data_error);
 		    cJSON_AddNumberToObject(j_stream, "packets", sp->packet_count);
 
 		    iperf_time_diff(&sp->result->start_time, &sp->result->start_time, &temp_time);
@@ -2219,8 +2232,10 @@ get_results(struct iperf_test *test)
     cJSON *j_errors;
     cJSON *j_packets;
     cJSON *j_server_output;
+    cJSON *j_data_errors;
     cJSON *j_start_time, *j_end_time;
     int sid, cerror, pcount;
+    int data_error;
     double jitter;
     iperf_size_t bytes_transferred;
     int retransmits;
@@ -2274,9 +2289,10 @@ get_results(struct iperf_test *test)
 			j_jitter = cJSON_GetObjectItem(j_stream, "jitter");
 			j_errors = cJSON_GetObjectItem(j_stream, "errors");
 			j_packets = cJSON_GetObjectItem(j_stream, "packets");
+                        j_data_errors = cJSON_GetObjectItem(j_stream, "data_errors"); 
 			j_start_time = cJSON_GetObjectItem(j_stream, "start_time");
 			j_end_time = cJSON_GetObjectItem(j_stream, "end_time");
-			if (j_id == NULL || j_bytes == NULL || j_retransmits == NULL || j_jitter == NULL || j_errors == NULL || j_packets == NULL) {
+			if (j_id == NULL || j_bytes == NULL || j_retransmits == NULL || j_jitter == NULL || j_errors == NULL || j_packets == NULL || j_data_errors == NULL) {
 			    i_errno = IERECVRESULTS;
 			    r = -1;
 			} else {
@@ -2285,6 +2301,7 @@ get_results(struct iperf_test *test)
 			    retransmits = j_retransmits->valueint;
 			    jitter = j_jitter->valuedouble;
 			    cerror = j_errors->valueint;
+                            data_error = j_data_errors->valueint;
 			    pcount = j_packets->valueint;
 			    SLIST_FOREACH(sp, &test->streams, streams)
 				if (sp->id == sid) break;
@@ -2295,6 +2312,7 @@ get_results(struct iperf_test *test)
 				if (sp->sender) {
 				    sp->jitter = jitter;
 				    sp->cnt_error = cerror;
+                                    sp->data_error = data_error;
 				    sp->peer_packet_count = pcount;
 				    sp->result->bytes_received = bytes_transferred;
 				    /*
@@ -2861,6 +2879,9 @@ iperf_reset_test(struct iperf_test *test)
     test->bidirectional = 0;
     test->no_delay = 0;
 
+    test->data_val = 0;
+
+
     FD_ZERO(&test->read_set);
     FD_ZERO(&test->write_set);
     
@@ -3015,15 +3036,18 @@ iperf_stats_callback(struct iperf_test *test)
 		temp.interval_packet_count = sp->packet_count;
 		temp.interval_outoforder_packets = sp->outoforder_packets;
 		temp.interval_cnt_error = sp->cnt_error;
+   		temp.interval_data_error = sp->data_error;
 	    } else {
 		temp.interval_packet_count = sp->packet_count - irp->packet_count;
 		temp.interval_outoforder_packets = sp->outoforder_packets - irp->outoforder_packets;
 		temp.interval_cnt_error = sp->cnt_error - irp->cnt_error;
+                temp.interval_data_error = sp->data_error - irp->data_error;
 	    }
 	    temp.packet_count = sp->packet_count;
 	    temp.jitter = sp->jitter;
 	    temp.outoforder_packets = sp->outoforder_packets;
 	    temp.cnt_error = sp->cnt_error;
+            temp.data_error = sp->data_error;
 	}
         add_to_interval_list(rp, &temp);
         rp->bytes_sent_this_interval = rp->bytes_received_this_interval = 0;
@@ -3148,7 +3172,6 @@ iperf_print_intermediate(struct iperf_test *test)
         int total_packets = 0, lost_packets = 0;
         double avg_jitter = 0.0, lost_percent;
         int stream_must_be_sender = current_mode * current_mode;
-
         /*  Print stream role just for bidirectional mode. */
 
         if (test->mode == BIDIRECTIONAL) {
@@ -3201,14 +3224,17 @@ iperf_print_intermediate(struct iperf_test *test)
                         /* Interval sum, TCP with retransmits. */
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  retransmits: %d  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, (int64_t) retransmits, irp->omitted, stream_must_be_sender)); /* XXX irp->omitted or test->omitting? */
-                        else
+                        else {
                             iperf_printf(test, report_sum_bw_retrans_format, mbuf, start_time, end_time, ubuf, nbuf, retransmits, irp->omitted?report_omitted:""); /* XXX irp->omitted or test->omitting? */
+                        }
                     } else {
                         /* Interval sum, TCP without retransmits. */
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, test->omitting, stream_must_be_sender));
-                        else
+                        else {
                             iperf_printf(test, report_sum_bw_format, mbuf, start_time, end_time, ubuf, nbuf, test->omitting?report_omitted:"");
+
+                        }                            
                     }
                 } else {
                     /* Interval sum, UDP. */
@@ -3227,8 +3253,9 @@ iperf_print_intermediate(struct iperf_test *test)
                         }
                         if (test->json_output)
                             cJSON_AddItemToObject(json_interval, "sum", iperf_json_printf("start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  omitted: %b sender: %b", (double) start_time, (double) end_time, (double) irp->interval_duration, (int64_t) bytes, bandwidth * 8, (double) avg_jitter * 1000.0, (int64_t) lost_packets, (int64_t) total_packets, (double) lost_percent, test->omitting, stream_must_be_sender));
-                        else
+                        else {
                             iperf_printf(test, report_sum_bw_udp_format, mbuf, start_time, end_time, ubuf, nbuf, avg_jitter * 1000.0, lost_packets, total_packets, lost_percent, test->omitting?report_omitted:"");
+                        }                            
                     }
                 }
             }
@@ -3434,6 +3461,8 @@ iperf_print_results(struct iperf_test *test)
                             }
                             else {
                                 iperf_printf(test, report_bw_retrans_format, sp->socket, mbuf, start_time, sender_time, ubuf, nbuf, sp->result->stream_retrans, report_sender);
+                                if (sp->data_error > 0)
+		                    iperf_printf(test, report_sum_data_error_packets, sp->data_error);                                
                             }
                     } else {
                         /* Sender summary, TCP and SCTP without retransmits. */
@@ -3446,6 +3475,8 @@ iperf_print_results(struct iperf_test *test)
                             }
                             else {
                                 iperf_printf(test, report_bw_format, sp->socket, mbuf, start_time, sender_time, ubuf, nbuf, report_sender);
+                                if (sp->data_error > 0)
+		                    iperf_printf(test, report_sum_data_error_packets, sp->data_error);                                
                             }
                     }
                 } else {
@@ -3474,7 +3505,7 @@ iperf_print_results(struct iperf_test *test)
                          * instead.
                          */
                         int packet_count = sender_packet_count ? sender_packet_count : receiver_packet_count;
-                        cJSON_AddItemToObject(json_summary_stream, "udp", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  out_of_order: %d sender: %b", (int64_t) sp->socket, (double) start_time, (double) sender_time, (double) sender_time, (int64_t) bytes_sent, bandwidth * 8, (double) sp->jitter * 1000.0, (int64_t) (sp->cnt_error - sp->omitted_cnt_error), (int64_t) (packet_count - sp->omitted_packet_count), (double) lost_percent, (int64_t) (sp->outoforder_packets - sp->omitted_outoforder_packets), stream_must_be_sender));
+                        cJSON_AddItemToObject(json_summary_stream, "udp", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f  jitter_ms: %f  lost_packets: %d  packets: %d  lost_percent: %f  out_of_order: %d sender: %b data_errors: %d", (int64_t) sp->socket, (double) start_time, (double) sender_time, (double) sender_time, (int64_t) bytes_sent, bandwidth * 8, (double) sp->jitter * 1000.0, (int64_t) (sp->cnt_error - sp->omitted_cnt_error), (int64_t) (packet_count - sp->omitted_packet_count), (double) lost_percent, (int64_t) (sp->outoforder_packets - sp->omitted_outoforder_packets), stream_must_be_sender, (int64_t) sp->data_error));
                     }
                     else {
                         /*
@@ -3493,6 +3524,9 @@ iperf_print_results(struct iperf_test *test)
                         }
                         if ((sp->outoforder_packets - sp->omitted_outoforder_packets) > 0)
                           iperf_printf(test, report_sum_outoforder, mbuf, start_time, sender_time, (sp->outoforder_packets - sp->omitted_outoforder_packets));
+                        if (sp->data_error > 0)
+		            iperf_printf(test, report_sum_data_error_packets, sp->data_error);
+
                     }
                 }
 
@@ -3529,7 +3563,7 @@ iperf_print_results(struct iperf_test *test)
                 if (test->protocol->id == Ptcp || test->protocol->id == Psctp) {
                     /* Receiver summary, TCP and SCTP */
                     if (test->json_output)
-                        cJSON_AddItemToObject(json_summary_stream, "receiver", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f sender: %b", (int64_t) sp->socket, (double) start_time, (double) receiver_time, (double) end_time, (int64_t) bytes_received, bandwidth * 8, stream_must_be_sender));
+                        cJSON_AddItemToObject(json_summary_stream, "receiver", iperf_json_printf("socket: %d  start: %f  end: %f  seconds: %f  bytes: %d  bits_per_second: %f sender: %b data_errors: %d", (int64_t) sp->socket, (double) start_time, (double) receiver_time, (double) end_time, (int64_t) bytes_received, bandwidth * 8, stream_must_be_sender, (int64_t) sp->data_error));
                     else
                         if (test->role == 's' && sp->sender) {
                             if (test->verbose)

--- a/src/iperf_locale.c
+++ b/src/iperf_locale.c
@@ -117,6 +117,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
     
                            "  -d, --debug               emit debugging output\n"
                            "  -v, --version             show version information and quit\n"
+                           "  -x  --dataval             enable data validation\n"
                            "  -h, --help                show this message and quit\n"
                            "Server specific:\n"
                            "  -s, --server              run in server mode\n"
@@ -396,6 +397,9 @@ const char report_outoforder[] =
 
 const char report_sum_outoforder[] =
 "[SUM]%s %4.1f-%4.1f sec  %d datagrams received out-of-order\n";
+
+const char report_sum_data_error_packets[] =
+"[SUM] %d datagrams failed data validation\n";
 
 const char report_peer[] =
 "[%3d] local %s port %u connected with %s port %u\n";

--- a/src/iperf_locale.h
+++ b/src/iperf_locale.h
@@ -88,6 +88,7 @@ extern const char report_omitted[] ;
 extern const char report_bw_separator[] ;
 extern const char report_outoforder[] ;
 extern const char report_sum_outoforder[] ;
+extern const char report_sum_data_error_packets[];
 extern const char report_peer[] ;
 extern const char report_mss_unsupported[] ;
 extern const char report_mss[] ;

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -63,8 +63,10 @@ iperf_tcp_recv(struct iperf_stream *sp)
     int index;
     char dblErr = 0;    
 
-    //r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Ptcp);
-    r = recv(sp->socket, sp->buffer, sp->settings->blksize, MSG_TRUNC);
+    if (sp->test->data_val == 1)
+        r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Ptcp);
+    else 
+        r = recv(sp->socket, sp->buffer, sp->settings->blksize, MSG_TRUNC);
 
     if (r < 0)
         return r;
@@ -74,7 +76,7 @@ iperf_tcp_recv(struct iperf_stream *sp)
      * Have to handle case where pattern restarts to zero at any point in bfr since back to back data blocks occur in TCP
      */
 
-    if (sp->test->data_val == 1) {
+    if (sp->test->data_val == 1 && r > 1) {
         ptrData = (unsigned char *)sp->buffer;
         for (index = 0; index < r; index++) {
             if (index == 0) {

--- a/src/iperf_tcp.c
+++ b/src/iperf_tcp.c
@@ -59,12 +59,53 @@ int
 iperf_tcp_recv(struct iperf_stream *sp)
 {
     int r;
+    unsigned char *ptrData, valCheck;
+    int index;
+    char dblErr = 0;    
 
     //r = Nread(sp->socket, sp->buffer, sp->settings->blksize, Ptcp);
     r = recv(sp->socket, sp->buffer, sp->settings->blksize, MSG_TRUNC);
 
     if (r < 0)
         return r;
+
+    /* If data validation enabled, check for incrementing data pattern
+     * The first byte is not validated; it is considered first byte of pattern
+     * Have to handle case where pattern restarts to zero at any point in bfr since back to back data blocks occur in TCP
+     */
+
+    if (sp->test->data_val == 1) {
+        ptrData = (unsigned char *)sp->buffer;
+        for (index = 0; index < r; index++) {
+            if (index == 0) {
+                // First byte is the start of pattern
+                valCheck = *ptrData + 1;
+                ptrData++;
+            }
+            else if (*ptrData != valCheck) {
+                // Pattern did not match.  Check for condition where this is start of next bfr
+                if (*ptrData == 0 && dblErr == 0) {
+
+                    // This appears to be start of next bfr, so do not fail
+                    // Set the double error flag so if next byte is also zero, we fail the validation
+                    dblErr = 1;
+                    ptrData++;
+                    valCheck = 1;
+                }         
+                else {
+                    sp->data_error++;
+                    iperf_err(sp->test, "Validation Error- index = %d, expected = %d, actual = %d", index, valCheck, (int)*ptrData);
+                    break;
+                }
+            }
+            else {
+                // Since patterns match, clear the double error flag
+                dblErr = 0;
+                ptrData++;
+                valCheck++;
+            }
+        }
+    }
 
     /* Only count bytes received while we're in the correct state. */
     if (sp->test->state == TEST_RUNNING) {
@@ -192,9 +233,19 @@ int
 iperf_tcp_send(struct iperf_stream *sp)
 {
     int r;
+    unsigned char *ptrData;
+    int index;
 
     if (!sp->pending_size)
 	sp->pending_size = sp->settings->blksize;
+
+    // Add pattern starting with ZERO if data validation enabled
+    if (sp->test->data_val == 1) {
+        ptrData = (unsigned char *)sp->buffer;
+        for (index=0; index < sp->pending_size ; index++) {
+            *ptrData++ = (unsigned char) index;
+        }
+    }
 
     if (sp->test->zc_api) {
 	iperf_tcp_zc_complete(sp->socket);

--- a/src/iperf_udp.c
+++ b/src/iperf_udp.c
@@ -75,6 +75,8 @@ iperf_udp_recv(struct iperf_stream *sp)
     int       first_packet = 0;
     double    transit = 0, d = 0;
     struct iperf_time sent_time, arrival_time, temp_time;
+    unsigned char *ptrData;
+    int index;
 
     r = Nread(sp->socket, sp->buffer, size, Pudp);
 
@@ -85,6 +87,23 @@ iperf_udp_recv(struct iperf_stream *sp)
      */
     if (r <= 0)
         return r;
+
+    // Check for fixed data pattern that starts with zero after 3 parameters 
+    
+    if (sp->test->data_val == 1) {
+        ptrData = (unsigned char *)sp->buffer+12;
+        for (index = 0; index < (r-12); index++) {
+            if (*ptrData != (unsigned char) index) {
+                sp->data_error++;
+                iperf_err(sp->test, "Validation Error- index = %d, expected = %d, actual = %d", index, index, (int)*ptrData);
+
+                break;
+            }
+            else {
+                ptrData++;
+            }
+        }
+    }
 
     /* Only count bytes received while we're in the correct state. */
     if (sp->test->state == TEST_RUNNING) {
@@ -215,6 +234,8 @@ iperf_udp_send(struct iperf_stream *sp)
     int r;
     int       size = sp->settings->blksize;
     struct iperf_time before;
+    unsigned char *ptrData;
+    int index;
 
     iperf_time_now(&before);
 
@@ -246,6 +267,15 @@ iperf_udp_send(struct iperf_stream *sp)
 	memcpy(sp->buffer+4, &usec, sizeof(usec));
 	memcpy(sp->buffer+8, &pcount, sizeof(pcount));
 	
+    }
+
+   // If data validation enabled, add pattern starting with ZERO after first 3 parameters
+
+    if (sp->test->data_val == 1) {
+        ptrData = (unsigned char *)sp->buffer+12;
+        for (index=0; index < (size - 12) ; index++) {
+            *ptrData++ = (unsigned char) index;
+        }
     }
 
     r = Nwrite(sp->socket, sp->buffer, size, Pudp);


### PR DESCRIPTION
These changes add UDP and TCP data validation support through the -x or --dataval parameter. They need to be used together on both the client and server for it to work every time.

If running in JSON output mode:

  For TCP, data_errors is added to end:streams:receiver
  For UDP, data_errors is added to end:streams:udp

If not running in JSON output mode, there will be a [SUM[ x datagrams failed data validation on the client like other errors IF a failure occurred

Whenever there is a data validation failure on the server, a validation error message is printed to the screen with the buffer index, expected value and actual value.  The message ONLY prints the first character of the buffer that is wrong

To test a failure case, you can run the client without -x and the server with -x.  It will only fail the first run as the server then gets the run parameter from the client for all subsequent runs

There are no data error statistics for individual intervals in this version

NOTE THAT WHEN RUNNING TCP DATA VALIDATION, iperf_tcp_recv using Nread instead of recv with MSG_TRUNC.  Otherwise, validation could not be done.  If running without data validation, recv with MSG_TRUNC is used.
